### PR TITLE
chore(release): test fast release workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,8 @@ jobs:
     # Auto-review ALL pull requests with Claude
     # BYPASS: Add [EMERGENCY], [SKIP REVIEW], or [HOTFIX] to PR title
     # BYPASS: Or add 'emergency' or 'skip-review' label to PR
+    # SKIP: Release PRs (dev → main) - already reviewed in dev
+    if: github.event.pull_request.base.ref != 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 10  # Prevent hung runs (Claude API timeout)
     permissions:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   audit:
+    # Skip security audit for release PRs (dev → main)
+    # Code was already audited when merging to dev
+    if: github.event.pull_request.base.ref != 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 5  # Prevent hung runs (Claude API timeout)
     concurrency:


### PR DESCRIPTION
## Test Release PR

This PR tests the new fast release workflow:
- ✅ Claude Code Review: SKIPPED (only runs for feature PRs)
- ✅ Security Audit: SKIPPED (only runs for feature PRs)
- ✅ Lint/Tests/Docs/Security: Required
- ✅ Allow dev → main: Required

Should merge in ~20 seconds instead of 5-15 minutes!

---

**Changes**: Skip slow Claude checks for release PRs