### PR TITLE
docs: improve Smithery badge placement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Claude Code Tresor 🏆
 
-[![Run in Smithery](https://smithery.ai/badge/skills/alirezarezvani)](https://smithery.ai/skills?ns=alirezarezvani&utm_source=github&utm_medium=badge)
-
-
 > A world-class collection of Claude Code utilities: autonomous skills, expert agents, slash commands, and prompts that supercharge your development workflow.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -10,6 +7,9 @@
 [![Quality](https://img.shields.io/badge/quality-9.7%2F10-brightgreen.svg)](docs/VALIDATION-REPORT-CONTENT.md)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Compatible-blue.svg)](https://claude.ai/code)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
+## Also available on Smithery:
+[![Run in Smithery](https://smithery.ai/badge/skills/alirezarezvani)](https://smithery.ai/skills?ns=alirezarezvani&utm_source=github&utm_medium=badge)
 
 **Author**: Alireza Rezvani
 **Created**: September 16, 2025


### PR DESCRIPTION
# Improve Smithery Badge Placement

## 📝 Changes

**Moved Smithery badge to dedicated section**

**Before:**
```markdown
# Claude Code Tresor 🏆

[![Run in Smithery](...)]  ← At very top

> A world-class collection...
```

**After:**
```markdown
# Claude Code Tresor 🏆

> A world-class collection...

[Other badges...]

## Also available on Smithery:
[![Run in Smithery](...)]  ← Clear context
```

---

## 🎯 Improvements

**Better Visual Hierarchy:**
- Title and tagline first
- Standard badges (License, Version, etc.) grouped together
- Smithery availability in dedicated section

**Clearer Context:**
- "Also available on Smithery" heading provides context
- Users immediately understand what the badge means
- Professional documentation layout

---

## ✅ Testing

- [ ] README.md renders correctly on GitHub
- [ ] Smithery badge links work
- [ ] Visual hierarchy improved

---

**Type:** Documentation improvement
**Impact:** Cosmetic (improves readability)
**Breaking Changes:** None

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>