### PR TITLE
Add deep dive section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Claude Code Tresor is the ultimate collection of **professional-grade utilities*
 > **💡 Ecosystem Tip:** Looking for more? Check out the [Claude Code Skill Factory](https://github.com/alirezarezvani/claude-code-skill-factory) to build custom skills, or browse the [Claude Skills Library](https://github.com/alirezarezvani/claude-skills) for pre-built professional domain packages. See [Related Projects](#-related-projects--ecosystem) for details.
 >
 > **📖 [Complete Augmentation Guide](https://gist.github.com/alirezarezvani/a0f6e0a984d4a4adc4842bbe124c5935)** - Comprehensive guide with FAQs, use cases, and installation instructions
+>
+> ## 📚 Deep Dive
+
+Want to understand the architecture behind this 141-agent setup?
+- [141 Claude Code Agents: The Setup That Actually Works](MEDIUM_URL)
 
 ---
 


### PR DESCRIPTION
Added a section for a deep dive into the architecture of the 141-agent setup.