### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #60)

### DIFF
--- a/commands/documentation/docs-gen.md
+++ b/commands/documentation/docs-gen.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, WebFetch
-argument-hint: [api|readme|guide|reference] [--format markdown|html|openapi|docusaurus] [--output path] [--include examples,diagrams] [--template custom] [--auto-deploy]
+argument-hint: "[api|readme|guide|reference] [--format markdown|html|openapi|docusaurus] [--output path] [--include examples,diagrams] [--template custom] [--auto-deploy]"
 description: Generate comprehensive documentation from code including API docs, user guides, and interactive documentation with deployment automation
 model: inherit
 ---

--- a/commands/operations/deploy-validate/deploy-validate.md
+++ b/commands/operations/deploy-validate/deploy-validate.md
@@ -1,7 +1,7 @@
 ---
 name: deploy-validate
 description: Pre-deployment validation with tests, security checks, config safety, and environment readiness verification
-argument-hint: [--env staging,production] [--skip-tests] [--quick]
+argument-hint: "[--env staging,production] [--skip-tests] [--quick]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/operations/health-check/health-check.md
+++ b/commands/operations/health-check/health-check.md
@@ -1,7 +1,7 @@
 ---
 name: health-check
 description: Comprehensive system health verification for production monitoring and incident detection
-argument-hint: [--env staging,production] [--comprehensive] [--alert]
+argument-hint: "[--env staging,production] [--comprehensive] [--alert]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/operations/incident-response/incident-response.md
+++ b/commands/operations/incident-response/incident-response.md
@@ -1,7 +1,7 @@
 ---
 name: incident-response
 description: Production incident coordination with emergency triage, RCA, and postmortem generation
-argument-hint: [--severity p0,p1,p2] [--skip-triage] [--postmortem]
+argument-hint: "[--severity p0,p1,p2] [--skip-triage] [--postmortem]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/performance/benchmark/benchmark.md
+++ b/commands/performance/benchmark/benchmark.md
@@ -1,7 +1,7 @@
 ---
 name: benchmark
 description: Load testing and performance benchmarking with intelligent scenario generation
-argument-hint: [--duration 5m,10m,30m] [--rps 10,50,100] [--pattern baseline,stress,spike,soak] [--tool locust,artillery,k6]
+argument-hint: "[--duration 5m,10m,30m] [--rps 10,50,100] [--pattern baseline,stress,spike,soak] [--tool locust,artillery,k6]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/performance/profile/profile.md
+++ b/commands/performance/profile/profile.md
@@ -1,7 +1,7 @@
 ---
 name: profile
 description: Comprehensive performance profiling with bottleneck identification and optimization recommendations
-argument-hint: [--layers frontend,backend,database,all] [--depth quick,standard,deep] [--threshold 500ms]
+argument-hint: "[--layers frontend,backend,database,all] [--depth quick,standard,deep] [--threshold 500ms]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/quality/code-health/code-health.md
+++ b/commands/quality/code-health/code-health.md
@@ -1,7 +1,7 @@
 ---
 name: code-health
 description: Codebase health assessment with quality metrics, test coverage, documentation, and maintainability analysis
-argument-hint: [--scope quality,tests,docs,all] [--threshold 7.0] [--report]
+argument-hint: "[--scope quality,tests,docs,all] [--threshold 7.0] [--report]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/quality/debt-analysis/debt-analysis.md
+++ b/commands/quality/debt-analysis/debt-analysis.md
@@ -1,7 +1,7 @@
 ---
 name: debt-analysis
 description: Technical debt identification with prioritization, effort estimation, and refactoring roadmap
-argument-hint: [--category architecture,code,test,documentation,all] [--prioritize cost,risk,effort]
+argument-hint: "[--category architecture,code,test,documentation,all] [--prioritize cost,risk,effort]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/security/audit/audit.md
+++ b/commands/security/audit/audit.md
@@ -1,7 +1,7 @@
 ---
 name: audit
 description: Comprehensive security audit with intelligent multi-phase orchestration and automatic agent selection
-argument-hint: [--scope security,compliance,infrastructure,all] [--parallel-max 3] [--report-format markdown,json]
+argument-hint: "[--scope security,compliance,infrastructure,all] [--parallel-max 3] [--report-format markdown,json]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/security/compliance-check/compliance-check.md
+++ b/commands/security/compliance-check/compliance-check.md
@@ -1,7 +1,7 @@
 ---
 name: compliance-check
 description: Regulatory compliance validation for GDPR, SOC2, HIPAA, PCI-DSS, and other frameworks
-argument-hint: [--frameworks gdpr,soc2,hipaa,pci,iso27001,all] [--data-flow] [--generate-report]
+argument-hint: "[--frameworks gdpr,soc2,hipaa,pci,iso27001,all] [--data-flow] [--generate-report]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/security/vulnerability-scan/vulnerability-scan.md
+++ b/commands/security/vulnerability-scan/vulnerability-scan.md
@@ -1,7 +1,7 @@
 ---
 name: vulnerability-scan
 description: Deep vulnerability analysis with CVE scanning, dependency analysis, and exploit correlation
-argument-hint: [--depth surface,deep,exhaustive] [--auto-fix] [--severity critical,high,all]
+argument-hint: "[--depth surface,deep,exhaustive] [--auto-fix] [--severity critical,high,all]"
 allowed-tools: Task, Read, Write, Edit, Bash, Glob, Grep, SlashCommand, AskUserQuestion
 model: inherit
 enabled: true

--- a/commands/testing/test-gen.md
+++ b/commands/testing/test-gen.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
-argument-hint: [--file path] [--type unit|component|integration|e2e|api] [--framework jest|vitest|playwright] [--coverage number] [--mocks auto|manual] [--output-dir path]
+argument-hint: "[--file path] [--type unit|component|integration|e2e|api] [--framework jest|vitest|playwright] [--coverage number] [--mocks auto|manual] [--output-dir path]"
 description: Generate comprehensive test suites automatically for components, functions, and APIs with multiple framework support
 model: inherit
 ---

--- a/commands/workflow/create-prompt/create-prompt.md
+++ b/commands/workflow/create-prompt/create-prompt.md
@@ -1,7 +1,7 @@
 ---
 name: create-prompt
 description: Expert prompt engineer that creates optimized, XML-structured prompts with intelligent depth selection
-argument-hint: [task description]
+argument-hint: "[task description]"
 allowed-tools: Task, Read, Write, Bash, Glob
 model: inherit
 enabled: true

--- a/commands/workflow/prompt-create/prompt-create.md
+++ b/commands/workflow/prompt-create/prompt-create.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-create
 description: Expert prompt engineer that creates optimized, XML-structured prompts with intelligent depth selection
-argument-hint: [task description]
+argument-hint: "[task description]"
 allowed-tools: Task, Read, Write, Bash, Glob
 model: inherit
 enabled: true

--- a/commands/workflow/review/review.md
+++ b/commands/workflow/review/review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Task, Bash(git status:*), Bash(git diff:*), Bash(git log:*), Read, Grep, Glob
-argument-hint: [--scope staged|unstaged|pr|commit] [--checks security,performance,style] [--format detailed|json] [--severity critical|high|medium] [--output filename]
+argument-hint: "[--scope staged|unstaged|pr|commit] [--checks security,performance,style] [--format detailed|json] [--severity critical|high|medium] [--output filename]"
 description: Comprehensive code review with security, performance, and configuration safety analysis using specialized agents
 model: inherit
 ---


### PR DESCRIPTION
Closes #60.

## Summary

Purely mechanical single-character transform to 15 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (15)

- `commands/quality/debt-analysis/debt-analysis.md`
- `commands/workflow/review/review.md`
- `commands/quality/code-health/code-health.md`
- `commands/documentation/docs-gen.md`
- `commands/operations/incident-response/incident-response.md`
- `commands/operations/deploy-validate/deploy-validate.md`
- `commands/performance/profile/profile.md`
- `commands/workflow/prompt-create/prompt-create.md`
- `commands/operations/health-check/health-check.md`
- `commands/workflow/create-prompt/create-prompt.md`
- `commands/performance/benchmark/benchmark.md`
- `commands/security/compliance-check/compliance-check.md`
- `commands/security/vulnerability-scan/vulnerability-scan.md`
- `commands/security/audit/audit.md`
- `commands/testing/test-gen.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
